### PR TITLE
cnwan-operator v1.0.0 chart

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -1,0 +1,54 @@
+name: Generate Chart Readme
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/cnwan-operator/values.yaml"
+      - "charts/cnwan-operator/Chart.yaml"
+      - "charts/cnwan-operator/README.md.gotmpl"
+
+jobs:
+  generate-chart-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout norwoodj/helm-docs
+        uses: actions/checkout@v2
+        with:
+          repository: norwoodj/helm-docs
+          path: readme-generator
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+
+      - name: Cache go mod
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install helm-docs
+        run: cd readme-generator/cmd/helm-docs && go build -a -o helm-docs *.go
+
+      - name: Checkout to repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          path: charts
+
+      - name: Generate Readme
+        run: ./readme-generator/cmd/helm-docs/helm-docs ./charts/cnwan-operator
+
+      - run: |
+          cd charts
+          git config user.email cnwan@cisco.com
+          git config user.name CN-WAN Bot
+          git add ./charts/cnwan-operator/README.md
+          git diff-index --quiet HEAD || git commit -s -m "Generate chart readme"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.email cnwan@cisco.com
+          git config user.name CN-WAN Bot
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: latest
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+cnwan-helm-charts
+
+Copyright (c) 2021 Cisco Systems, Inc. and/or its affiliates
+
+This project includes software developed at Cisco Systems, Inc. and/or its affiliates.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,5 @@
+This file lists the committers for the [CloudNativeSDWAN/cnwan-helm-charts](https://github.com/CloudNativeSDWAN/cnwan-helm-charts) repo.
+
+* Elis Lulja ([SunSince90](https://github.com/SunSince90)) ([elulja@cisco.com](mailto:elulja@cisco.com))
+* Alberto Rodriguez-Natal ([arnatal](https://github.com/arnatal)) ([natal@cisco.com](mailto:natal@cisco.com))
+* Lori Jakab ([ljakab](https://github.com/ljakab)) ([lojakab@cisco.com](mailto:lojakab@cisco.com))

--- a/README.md
+++ b/README.md
@@ -1,3 +1,84 @@
 # Helm charts for the Cloud-Native SD-WAN project components
 
-This repository will first publish a Helm chart for the CN-WAN operator.
+This repository hosts *Helm* charts for the components of the *Cloud-Native
+SD-WAN Project*.
+
+## TL;DR
+
+```bash
+helm repo add cnwan https://CloudNativeSDWAN.github.io/cnwan-helm-charts
+kubectl create ns cnwan-operator-system
+helm install cnwan-operator cnwan/<chart>
+```
+
+## Before you begin
+
+### Prerequisites
+
+- Kubernetes 1.10+
+- Helm 3.1.0
+
+### Install Helm
+
+Helm helps you manage Kubernetes applications — *Helm Charts* help you define,
+install, and upgrade even the most complex Kubernetes application.
+
+To install Helm, refer to the [Helm install guide](https://github.com/helm/helm#install)
+and ensure that the `helm` binary is in the `PATH` of your shell.
+
+### Add Repo
+
+Run this command to download -- and later install -- all the charts from this
+repository:
+
+```bash
+helm repo add cnwan https://CloudNativeSDWAN.github.io/cnwan-helm-charts
+```
+
+### Install charts
+
+As of now, this repository allows you to install the *CN-WAN Operator*.
+
+There are multiple ways to install it on your cluster, and all are based
+on this command:
+
+```bash
+helm install cnwan-operator cnwan/cnwan-operator <settings>
+```
+
+Please refer to *CN-WAN Operator*'s [chart guide](./cnwan-operator/README.md)
+to learn more about the installation process and its
+[official repository](https://github.com/CloudNativeSDWAN/cnwan-operator) for
+the settings and understanding how it works.
+
+## Contributing
+
+Thank you for interest in contributing to this project.
+Before starting, please make sure you know and agree to our [Code of conduct](./code-of-conduct.md).
+
+1. Fork it
+2. Download your fork
+    `git clone https://github.com/your_username/cnwan-helm-charts && cd cnwan-helm-charts`
+3. Create your feature branch
+    `git checkout -b my-new-feature`
+4. Make changes and add them
+    `git add .`
+5. Commit your changes
+    `git commit -m 'Add some feature'`
+6. Push to the branch
+    `git push origin my-new-feature`
+7. Create new pull request to this repository
+
+Before opening a pull request, please make sure you have updated any relevant
+values in `Chart.yaml` and `values.yaml`, including:
+
+- `appVersion` in `Chart.yaml`
+- `version` in `Chart.yaml`
+- `description` in `Chart.yaml`
+- `image.tag` in `values.yaml`
+
+and documented any changes that you have made and would like to be merged.
+
+## License
+
+These charts are released under the Apache 2.0 license. See [LICENSE](./LICENSE)

--- a/charts/cnwan-operator/.helmignore
+++ b/charts/cnwan-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cnwan-operator/Chart.yaml
+++ b/charts/cnwan-operator/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+appVersion: "v0.5.0"
+version: "1.0.0"
+type: application
+name: cnwan-operator
+description: |
+  Register and manage your Kubernetes Services to a Service Registry.
+
+  `v0.5.0` makes it easier for you to deploy the operator on your cluster as it
+  does not need any dependency injected into it anymore, i.e. `ConfigMap`s and
+  `Secret`s will now be automatically retrieved by the operataor from the
+  cluster.
+
+  Additionally, in case you are running the operator on *GKE* and choosing to
+  use *Service Directory* you may now leave some of the settings empty and the
+  operator will detect your project ID and region automatically and therefore
+  set up *Service Directory* without you having to touch anything.
+# https://github.com/helm/helm/issues/6190
+kubeVersion: ">= 1.11.0-0"
+home: https://github.com/CloudNativeSDWAN/cnwan-operator
+icon: https://avatars.githubusercontent.com/u/66446392?s=200&v=4
+keywords:
+  - cluster
+  - sd-wan
+  - networking
+  - service-registry
+maintainers:
+  - name: CloudNativeSDWAN
+    email: cnwan@cisco.com
+    url: https://github.com/CloudNativeSDWAN/cnwan-operator/blob/master/OWNERS.md
+sources:
+  - https://github.com/CloudNativeSDWAN/cnwan-operator
+dependencies:
+- name: etcd
+  version: "> 6.2.0"
+  repository: https://charts.bitnami.com/bitnami
+  condition: operator.etcd.install

--- a/charts/cnwan-operator/README.md.gotmpl
+++ b/charts/cnwan-operator/README.md.gotmpl
@@ -1,0 +1,156 @@
+# CN-WAN Operator Helm Chart
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+## Useful links
+
+[Project's Homepage]({{ template "chart.homepage" . }})
+[Documentation](https://github.com/CloudNativeSDWAN/cnwan-operator#documentation)
+
+**Sources**:
+{{ template "chart.sourcesList" . }}
+
+## Requirements
+
+**Kubernetes Version**: `{{ template "chart.kubeVersion" . }}`
+
+{{ template "chart.requirementsTable" . }}
+
+The `bitnami/etcd` dependency is only required if you intend to install the
+operator together with etcd. Otherwise, i.e. if you have etcd already installed
+or do not want to use etcd, it won't be needed.
+
+## Values table
+
+The behavior of the operator and the ways it connects to and manages a service
+registry can be fine tuned by setting the parameters of `operator` according
+to your needs -- e.g. by setting a value to `operator.namespacePolicy` -- and
+those of the service registry according to the one you are going to use -- e.g.
+`operator.etcd` or `operator.googleServiceDirectory`.
+
+Values that start with `etcd` -- e.g. `etcd.auth.rbac.enabled` will configure
+the etcd cluster that will be installed along with the operator in case you set
+`operator.etcd.install` to `true`, otherwise they will be ignored.
+
+Alternatively, you may download the `values.yaml` file locally and modify those
+values directly from there:
+
+```bash
+helm show values cnwan/cnwan-operator > /path/to/values.yaml
+```
+
+Once you are satisfied with the values, run:
+
+```bash
+helm install my-operator sunsince90new/cnwan-operator -f /path/to/values.yaml
+```
+
+We highly recommend you to read the
+[official documentation](https://github.com/CloudNativeSDWAN/cnwan-operator/blob/master/docs/configuration.md)
+to better understand the operator's settings.
+
+Finally, look at [examples](#examples) to learn more.
+
+{{ template "chart.valuesTable" . }}
+
+***
+
+## Examples
+
+The following are quickstarts/examples to demonstrate how to deploy the
+operator and configure it to use a certain service registry.
+
+Refer to the [values table](#values-table) above for the meaning of the values
+that have been set as `--set` or `--set-file`.
+
+Please note that you can group all settings together with one `--set` only by
+separating all values with commas, but in the following examples we use
+`--set` for each separate setting to make the example more reader-friendly.
+
+### Usage with Google Service Directory
+
+This will deploy the operator to your cluster and will configure it to use
+Google Service Directory.
+
+It will need a valid
+[service account](https://cloud.google.com/iam/docs/service-accounts)
+in order to log in to GCP correctly: once you have located it, set its path
+with `--set-file operator.googleServiceDirectory.serviceAccount <path>`. In
+the following example, we assume its path is `$HOME/Desktop/service-account.json`.
+
+```bash
+kubectl create ns cnwan-operator-system
+helm install cnwan-operator cnwan/cnwan-operator \
+--set operator.namespaceListPolicy=allowlist \
+--set operator.serviceAnnotations="{traffic-profile}" \
+--set operator.serviceRegistry=ServiceDirectory \
+--set operator.googleServiceDirectory.projectID=my-project-dg502 \
+--set operator.googleServiceDirectory.defaultRegion=us-west2 \
+--set-file operator.googleServiceDirectory.serviceAccount=$HOME/Desktop/service-account.json \
+-n cnwan-operator-system
+```
+
+If you are going to deploy this on *GKE* and want to use your default project
+and you want your services to be registered on the same region as your *GKE*
+cluster, you may omit `defaultRegion` and `projectID` values, like so:
+
+```bash
+kubectl create ns cnwan-operator-system
+helm install cnwan-operator cnwan/cnwan-operator \
+--set operator.namespaceListPolicy=allowlist \
+--set operator.serviceAnnotations="{traffic-profile}" \
+--set operator.serviceRegistry=ServiceDirectory \
+--set-file operator.googleServiceDirectory.serviceAccount=$HOME/Desktop/service-account.json \
+-n cnwan-operator-system
+```
+
+### Usage with etcd
+
+You may choose to deploy the operator along with a brand new etcd installation
+and make it automatically configure the appropriate values for connecting and
+managing etcd, or decide to only deploy the operator. In the latter case, you
+may need to provide some values manually.
+
+For brevity, some of the values here have been omitted and their default values
+will apply in that case. Please refer to the [values table](#values-table)
+above if you want to add other values and to know what they mean.
+
+#### Installing the operator and etcd
+
+To deploy the operator and etcd together, you can run
+
+```bash
+kubectl create ns cnwan-operator-system
+helm install cnwan-operator cnwan/cnwan-operator \
+--set operator.serviceAnnotations="{traffic-profile}" \
+--set operator.serviceRegistry=etcd \
+--set operator.etcd.install=true \
+-n cnwan-operator-system
+```
+
+Now wait a few minutes until service registry gets into ready state
+
+```bash
+watch kubectl get pods -n cnwan-operator-system
+```
+
+#### Installing the operator without etcd
+
+This is the way to install the operator in case you have etcd already running
+somewhere or you just want to install it and managing. Let's suppose your etcd
+installation can be reached via DNS name `my-etcd.etcd` on port `8080` and the
+password is `my-PWD`.
+
+```bash
+kubectl create ns cnwan-operator-system
+helm install cnwan-operator cnwan/cnwan-operator \
+--set operator.serviceAnnotations="{traffic-profile}" \
+--set operator.serviceRegistry=etcd \
+--set operator.etcd.endpoints="{my-etcd.etcd:8080}" \
+--set operator.etcd.password="my-PWD" \
+-n cnwan-operator-system
+```
+
+{{ template "chart.maintainersSection" . }}

--- a/charts/cnwan-operator/ci/install-etcd-values.yaml
+++ b/charts/cnwan-operator/ci/install-etcd-values.yaml
@@ -1,0 +1,5 @@
+operator:
+  serviceAnnotations: [traffic-profile]
+  serviceRegistry: etcd
+  etcd:
+    install: true

--- a/charts/cnwan-operator/templates/NOTES.txt
+++ b/charts/cnwan-operator/templates/NOTES.txt
@@ -1,0 +1,7 @@
+Thank you for installing CN-WAN Operator!
+
+You can view the logs by running the following command:
+
+    kubectl logs -f $(kubectl get pods -o=jsonpath='{.items[0].metadata.name}')
+
+If you need to read more about its documentation please visit https://github.com/CloudNativeSDWAN/cnwan-operator.

--- a/charts/cnwan-operator/templates/_helpers.tpl
+++ b/charts/cnwan-operator/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cnwan-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+TODO: this is disabled because we don't support installing the operator on a
+namespace different from the default one.
+{{- define "cnwan-operator.fullname" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+*/}}
+{{- define "cnwan-operator.fullname" -}}
+{{ include "cnwan-operator.name" .}}
+{{- end}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cnwan-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cnwan-operator.labels" -}}
+helm.sh/chart: {{ include "cnwan-operator.chart" . }}
+{{ include "cnwan-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+cnwan.io/application: operator
+control-plane: controller-manager
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cnwan-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cnwan-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+cnwan.io/application: operator
+{{- end }}
+

--- a/charts/cnwan-operator/templates/cluster_role.yaml
+++ b/charts/cnwan-operator/templates/cluster_role.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name}}-cluster-role
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - services

--- a/charts/cnwan-operator/templates/cluster_role_binding.yaml
+++ b/charts/cnwan-operator/templates/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name}}-cluster-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Chart.Name }}-service-account
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}-cluster-role

--- a/charts/cnwan-operator/templates/configmap.yaml
+++ b/charts/cnwan-operator/templates/configmap.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name}}-settings
+data:
+  settings.yaml: |-
+      namespace:
+        {{- if and (ne .Values.operator.namespaceListPolicy "allowlist") (ne .Values.operator.namespaceListPolicy "blocklist") }}
+        {{- fail "namespaceListPolicy must be either allowlist or blocklist" }}
+        {{- else }}
+        listPolicy: {{ .Values.operator.namespaceListPolicy }}
+        {{- end }}
+      service:
+        {{- if .Values.operator.serviceAnnotations }}
+        annotations:
+        {{- range .Values.operator.serviceAnnotations }}
+          - {{ . }}
+        {{- end }}
+        {{- else }}
+        {{- fail "no service annotations provided" }}
+        {{- end }}
+      serviceRegistry:
+        {{- if and (ne (lower .Values.operator.serviceRegistry) "etcd") (ne (lower .Values.operator.serviceRegistry) "servicedirectory") }}
+        {{- fail "service registry defined in serviceRegistry is empty or not supported" }}
+        {{- end }}
+        {{- if eq (lower .Values.operator.serviceRegistry) "etcd" }}
+        etcd:
+          prefix: {{ .Values.operator.etcd.prefix }}
+          {{- if or (.Values.operator.etcd.username) (.Values.operator.etcd.password) }}
+          authentication: WithUsernameAndPassword
+          {{- end }}
+          {{- if .Values.operator.etcd.install }}
+          endpoints:
+            - host: {{ .Values.etcd.fullnameOverride }}.{{ .Release.Namespace }}
+          {{- else }}
+          {{- if .Values.operator.etcd.endpoints }}
+          endpoints:
+          {{- range .Values.operator.etcd.endpoints }}
+          {{- $parts := split ":" . }}
+            - host: {{ $parts._0 }}
+              {{- if $parts._1 }}
+              port: {{ $parts._1 }}
+              {{- end }}
+          {{- end }}
+          {{- else }}
+          {{- fail "no etcd endpoints provided" }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- if eq (lower .Values.operator.serviceRegistry) "servicedirectory" }}
+        {{- if or (.Values.operator.googleServiceDirectory.defaultRegion) (.Values.operator.googleServiceDirectory.projectID) }}
+        gcpServiceDirectory:
+          {{- if .Values.operator.googleServiceDirectory.defaultRegion }}
+          defaultRegion: {{ .Values.operator.googleServiceDirectory.defaultRegion }}
+          {{- end }}
+          {{- if .Values.operator.googleServiceDirectory.projectID }}
+          projectID: {{ .Values.operator.googleServiceDirectory.projectID }}
+          {{- end }}
+        {{- else }}
+        gcpServiceDirectory: {}
+        {{- end }}
+        {{- end }}
+        {{- if and
+          (.Values.operator.cloudMetadata)
+          (or (.Values.operator.cloudMetadata.network) (.Values.operator.cloudMetadata.subNetwork) )
+        }}
+        cloudMetadata:
+          {{- if .Values.operator.cloudMetadata.network }}
+          network: {{ .Values.operator.cloudMetadata.network }}
+          {{- end }}
+          {{- if .Values.operator.cloudMetadata.subNetwork }}
+          subNetwork: {{ .Values.operator.cloudMetadata.subNetwork }}
+          {{- end }}
+        {{- end }}

--- a/charts/cnwan-operator/templates/deployment.yaml
+++ b/charts/cnwan-operator/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}-controller-manager
+  labels:
+    {{- include "cnwan-operator.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "cnwan-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cnwan-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Chart.Name }}-service-account
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/cnwan-operator/templates/etcd_credentials.yaml
+++ b/charts/cnwan-operator/templates/etcd_credentials.yaml
@@ -1,0 +1,9 @@
+{{- if and (eq .Values.operator.serviceRegistry "etcd") (or (.Values.operator.etcd.username) (.Values.operator.etcd.password)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-credentials
+data:
+  username: {{ .Values.operator.etcd.username | b64enc }}
+  password: {{ .Values.operator.etcd.password | b64enc }}
+{{- end }}

--- a/charts/cnwan-operator/templates/etcd_root_password.yaml
+++ b/charts/cnwan-operator/templates/etcd_root_password.yaml
@@ -1,0 +1,8 @@
+{{- if and (eq (lower .Values.operator.serviceRegistry) "etcd") (.Values.operator.etcd.install) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-root-password
+data:
+  etcd-root-password: {{ .Values.operator.etcd.password | b64enc }}
+{{- end }}

--- a/charts/cnwan-operator/templates/google_service_account.yaml
+++ b/charts/cnwan-operator/templates/google_service_account.yaml
@@ -1,0 +1,9 @@
+{{- if eq (lower .Values.operator.serviceRegistry) "servicedirectory" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: google-service-account
+data:
+  google-service-account.json: |-
+{{ required "serviceAccount is empty" .Values.operator.googleServiceDirectory.serviceAccount | b64enc | indent 4 }}
+{{- end }}

--- a/charts/cnwan-operator/templates/role.yaml
+++ b/charts/cnwan-operator/templates/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name:  {{ .Chart.Name}}-role
+rules:
+- apiGroups: 
+  - ""
+  resources:
+  - "secrets"
+  - "configmaps"
+  verbs: 
+  - "get"
+  - "list"

--- a/charts/cnwan-operator/templates/role_binding.yaml
+++ b/charts/cnwan-operator/templates/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name}}-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name:  {{ .Chart.Name}}-service-account
+roleRef:
+  kind: Role
+  name:  {{ .Chart.Name}}-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/cnwan-operator/templates/serviceaccount.yaml
+++ b/charts/cnwan-operator/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}-service-account
+  labels:
+    {{- include "cnwan-operator.labels" . | nindent 4 }}

--- a/charts/cnwan-operator/values.yaml
+++ b/charts/cnwan-operator/values.yaml
@@ -1,0 +1,127 @@
+image:
+  # image.registry -- The registry where to get the container image.
+  registry: ghcr.io
+  # image.repository -- The repository where to get the container image inside
+  # the registry specified above.
+  repository: cloudnativesdwan/cnwan-operator
+  # image.tag -- The tag for the container image.
+  # @default -- The same as `appVersion` from `Chart.yaml`.
+  tag: ""
+  # image.pullPolicy -- The `pullPolicy` for this container image.
+  pullPolicy: Always
+  # image.pullSecrets -- Secrets to use to pull the image, in case the
+  # provided repository is private.
+  # @default -- The default repository is public, so no secret will be needed.
+  pullSecrets: []
+
+
+operator:
+  # operator.namespaceListPolicy -- The namespace list policy. Must be either
+  # `allowlist` or `blocklist`.
+  # [Learn more here](https://github.com/CloudNativeSDWAN/cnwan-operator/blob/master/docs/configuration.md)
+  namespaceListPolicy: allowlist
+
+  # operator.serviceAnnotations -- A list of service annotations that must be watched.
+  # **An error will occur if this is empty.**
+  # [Learn more here](https://github.com/CloudNativeSDWAN/cnwan-operator/blob/master/docs/configuration.md)
+  # @default -- **At least one item must be provided.**.
+  serviceAnnotations: []
+
+  # operator.serviceRegistry -- The service registry to use to register your resources.
+  # Must be either `etcd` or `ServiceDirectory`.
+  # @default -- Required: will throw an error if not provided or invalid.
+  serviceRegistry: <service-registry>
+
+  # operator.googleServiceDirectory -- Options about service directory. Will be
+  # ignored if `operator.serviceRegistry` is not `gcpServiceDirectory`.
+  # @default -- Read each value below.
+  googleServiceDirectory:
+
+    # operator.googleServiceDirectory.serviceAccount -- The path to the service
+    # account to use to authenticate to GCP. **DO NOT** set this explicitly,
+    # but rather supply this information during installation with `--set-file`.
+    # See [Examples](#examples) section.
+    # @default -- **DO NOT** set explicitly: see [Examples](#examples).
+    serviceAccount: ""
+
+    # operator.googleServiceDirectory.defaultRegion --  The default region to
+    # use for Service Directory. You *must* specify this, unless you are
+    # running in GKE *and* want to use the current region, in which case you
+    # can just omit this.
+    # @default -- If not provided, will be omitted from settings.
+    defaultRegion: ""
+
+    # operator.googleServiceDirectory.projectID --  The GCP project ID to
+    # use for Service Directory. You *must* specify this, unless you are
+    # running in GKE *and* want to use the current project, in which case you
+    # can just omit this.
+    # @default -- If not provided, will be omitted from settings.
+    projectID: ""
+
+  # operator.etcd -- Options about etcd.
+  # @default -- Read each value below.
+  etcd:
+
+    # operator.etcd.install -- Whether to install etcd in the current namespace.
+    # Set this to false or omit this if you plan to install it yourself or
+    # already have it running somewhere.
+    install: false
+
+    # operator.etcd.username -- The username to connect as.
+    username: root
+
+    # operator.etcd.username -- The password to use for the username provided
+    # in `operator.etcd.username`.
+    password: "dem0-pwd"
+
+    # operator.etcd.prefix -- The prefix that all keys will share.
+    prefix: "/service-registry"
+
+    # operator.etcd.endpoints -- A list of endpoints where your etcd nodes are
+    # serving from.
+    # @default -- If `operator.etcd.install` is true, this will be filled
+    # automatically, otherwise it will be `["etcd.etcd:2379"]`.
+    endpoints:
+      - "etcd.etcd:2379"
+
+  cloudMetadata:
+    # operator.cloudMetadata.network -- Whether to register the current
+    # network name (VPC) among a service's metadata.
+    # Set auto if you are running in GKE to retrieve this value automatically.
+    # Omit if you don't need this.
+    # @default -- If empty it will be omitted from settings.
+    network: ""
+
+    # operator.cloudMetadata.subNetwork -- Whether to register the current
+    # sub-network name among a service's metadata.
+    # Set auto if you are running in GKE to retrieve this value automatically.
+    # Omit if you don't need this.
+    # @default -- If empty it will be omitted from settings.
+    subNetwork: ""
+
+# etcd -- Options about the etcd to install along with the operator, in case
+# `operator.etcd.install` is true.
+# @default -- See each value below.
+etcd:
+  # etcd.fullnameOverride -- The name to give to the etcd installation if
+  # `operator.etcd.install` is true.
+  fullnameOverride: service-registry
+
+  service:
+    # etcd.service.type -- The Kubernetes service type to use to expose the
+    # etcd installation.
+    type: ClusterIP
+
+  auth:
+    rbac:
+      # etcd.auth.rbac.enabled -- Whether to enable RBAC for etcd.
+      enabled: true
+      # etcd.auth.rbac.allowNoneAuthentication -- Whether to allow connections
+      # to etcd as an unauthenticated user.
+      allowNoneAuthentication: false
+      # etcd.auth.rbac.existingSecret -- The name of the existing secret on
+      # your cluster where to get the root password. Please **do not** modify
+      # unless you know what you are doing.
+      # @default -- The secret will be automatically deployed by the chart and
+      # this value will be created internally.
+      existingSecret: etcd-root-password

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thank you for your interest in contributing to the CN-WAN helm charts. Please make sure you read the full code of conduct before making any contribution.
+
+Before contributing to this repository, please first create an issue discussing the change you wish to make or discuss about it via email with one of the owners of the project.
+
+We kindly ask you to follow the following code of conduct in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before asking to merge your code.
+2. Update the README.md with details of changes to the interface, including new environment variables, new values and defaults.
+3. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. Ask one (or more) of the code owners to review and merge your Pull Request.
+
+## Code of Conduct
+
+All participants of CN-WAN helm charts are expected to abide by our Code of Conduct, both online and during in-person events that are hosted and/or associated with CN-WAN helm charts.
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+### The Standards
+
+Examples of behaviour that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* Trolling, insulting/derogatory comments, public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Not being respectful to reasonable communication boundaries, such as 'leave me alone', 'go away', or 'I’m not discussing this with you'.
+* The usage of sexualised language or imagery and unwelcome sexual attention or advances
+* Swearing, usage of strong or disturbing language
+* Demonstrating the graphics or any other content you know may be considered disturbing
+* Starting and/or participating in arguments related to politics
+* Assuming or promoting any kind of inequality including but not limited to: age, body size, disability, ethnicity, gender identity and expression, nationality and race, personal appearance, religion, or sexual identity and orientation
+* Drug promotion of any kind
+* Attacking personal tastes
+* Other conduct which you know could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Violations of the Code of Conduct may be reported by sending an email to one of the owners or maintainers of the project, as listed in OWNERS. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
+
+We hold the right and responsibility to remove comments or other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any members for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+### Attribution
+
+This Code of Conduct is adapted from:
+
+* [Contributor Covenant, version 1.4](http://contributor-covenant.org/version/1/4)
+* [dev.to](https://dev.to/code-of-conduct)


### PR DESCRIPTION
This PR adds all relevant files for version `1.0.0` of the helm chart for the cnwan-operator, including `Chart.yaml`, `values.yaml` and all other files inside `/templates` and workflows for auto-releasing on merge and generating chart readme.