### PR TITLE
Fix releaser workflow

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -45,10 +45,16 @@ jobs:
       - name: Generate Readme
         run: ./readme-generator/cmd/helm-docs/helm-docs ./charts/cnwan-operator
 
-      - run: |
+      - name: Config git
+        run: |
           cd charts
           git config user.email cnwan@cisco.com
           git config user.name CN-WAN Bot
+
+      - name: Commit and push changes
+        run: |
+          cd charts
+          git pull
           git add ./charts/cnwan-operator/README.md
           git diff-index --quiet HEAD || git commit -s -m "Generate chart readme"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,38 @@ jobs:
         uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  update-index:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: charts-pages
+
+      - name: Copy index.yaml
+        run: cp charts-pages/index.yaml index.yaml
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Move index.yaml
+        run: mv index.yaml main/index.yaml
+
+      - name: Configure Git
+        run: |
+          cd main
+          git config user.email cnwan@cisco.com
+          git config user.name CN-WAN Bot
+
+      - name: Commit and push changes
+        run: |
+          cd main
+          git pull
+          git add .
+          git commit -s -m "Generate index.yaml"
+          git push


### PR DESCRIPTION
This updates the release workflow by copying the generated `index.yaml` file to the `main` branch and solves a concurrency issue caused by the readme generator and releaser workflows.