### PR TITLE
Fix workflow change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,5 +32,5 @@ jobs:
           fi
 
       - name: Lint
-        run: ct lint
+        run: ct lint --target-branch=main
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,5 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --namespace cnwan-operator-system
+        run: ct install --namespace cnwan-operator-system --target-branch=main
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
This commit fixes an issued caused by the chart linter and tester due to
them using `master` as default branch.
It now uses main.