### PR TITLE
Update to operator version 0.7.0

### DIFF
--- a/charts/cnwan-operator/Chart.yaml
+++ b/charts/cnwan-operator/Chart.yaml
@@ -1,25 +1,15 @@
 apiVersion: v2
-appVersion: "v0.6.0"
-version: "1.1.2"
+appVersion: "v0.7.0"
+version: "1.2.0"
 type: application
 name: cnwan-operator
 description: |
   Register and manage your Kubernetes Services to a Service Registry.
 
-  `v0.6.0` removes the old way of filtering namespaces to be watched with a
-  more intuitive way: instead of using concepts like `allowlist` or
-  `blocklist`, one can just set `true` or `false` in the new
-  `watchNamespacesByDefault`.
+  `v0.7.0` brings support for AWS Cloud Map, enabling the project to
+  reflect services inside your cluster to AWS's service registry.
 
-  The old labels used to filter them are now dropped in favor of just
-  `operator.cnwan.io/watch` with values `enabled` or `disabled`.
-  Please refer to our documentation to know how this works.
-
-  The old, deprecated way to provide options for Google Service Directory is
-  now definitively removed and some other packages have been removed as well,
-  making the project slimmer and smoother.
-
-  Some other improvements are also present.
+  Take a look to our changelog for a complete list of changes.
 # https://github.com/helm/helm/issues/6190
 kubeVersion: ">= 1.11.0-0"
 home: https://github.com/CloudNativeSDWAN/cnwan-operator

--- a/charts/cnwan-operator/README.md.gotmpl
+++ b/charts/cnwan-operator/README.md.gotmpl
@@ -152,3 +152,24 @@ helm install cnwan-operator cnwan/cnwan-operator \
 ```
 
 {{ template "chart.maintainersSection" . }}
+
+### Usage with AWS Cloud Map
+
+This will deploy the operator to your cluster and will configure it to use
+AWS Cloud Map.
+
+It will need a valid
+[credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where)
+in order to log in to AWS correctly: once you have located it, set its path
+with `--set-file operator.awsCloudMap.credentials <path>`. In
+the following example, we assume its path is `$HOME/Desktop/credentials`.
+
+```bash
+kubectl create ns cnwan-operator-system
+helm install cnwan-operator cnwan/cnwan-operator \
+--set operator.serviceAnnotations="{traffic-profile}" \
+--set operator.serviceRegistry=cloudmap \
+--set operator.awsCloudMap.defaultRegion=us-west-1 \
+--set-file operator.awsCloudMap.credentials=$HOME/Desktop/credentials \
+-n cnwan-operator-system
+```

--- a/charts/cnwan-operator/templates/aws_credentials.yaml
+++ b/charts/cnwan-operator/templates/aws_credentials.yaml
@@ -1,0 +1,9 @@
+{{- if eq (lower .Values.operator.serviceRegistry) "cloudmap" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+data:
+  credentials: |-
+{{ required "credentials is empty" .Values.operator.awsCloudMap.credentials | b64enc | indent 4 }}
+{{- end }}

--- a/charts/cnwan-operator/templates/configmap.yaml
+++ b/charts/cnwan-operator/templates/configmap.yaml
@@ -14,8 +14,16 @@ data:
         {{- fail "no service annotations provided" }}
         {{- end }}
       serviceRegistry:
-        {{- if and (ne (lower .Values.operator.serviceRegistry) "etcd") (ne (lower .Values.operator.serviceRegistry) "servicedirectory") }}
+        {{- if and (ne (lower .Values.operator.serviceRegistry) "etcd") (and (ne (lower .Values.operator.serviceRegistry) "servicedirectory") (ne (lower .Values.operator.serviceRegistry) "cloudmap") ) }}
         {{- fail "service registry defined in serviceRegistry is empty or not supported" }}
+        {{- end }}
+        {{- if eq (lower .Values.operator.serviceRegistry) "cloudmap" }}
+        awsCloudMap:
+          {{- if .Values.operator.awsCloudMap.defaultRegion }}
+          defaultRegion: {{ .Values.operator.awsCloudMap.defaultRegion }}
+          {{- else }}
+          {{- fail "no region provided for Cloud Map" }}
+          {{- end }}
         {{- end }}
         {{- if eq (lower .Values.operator.serviceRegistry) "etcd" }}
         etcd:

--- a/charts/cnwan-operator/values.yaml
+++ b/charts/cnwan-operator/values.yaml
@@ -44,7 +44,7 @@ operator:
   serviceAnnotations: []
 
   # operator.serviceRegistry -- The service registry to use to register your resources.
-  # Must be either `etcd` or `ServiceDirectory`.
+  # Must be either `etcd`, `ServiceDirectory` or `CloudMap`.
   # @default -- Required: will throw an error if not provided or invalid.
   serviceRegistry: <service-registry>
 
@@ -99,6 +99,22 @@ operator:
     # automatically, otherwise it will be `["etcd.etcd:2379"]`.
     endpoints:
       - "etcd.etcd:2379"
+
+  # operator.awsCloudMap -- Options about AWS Cloud Map.
+  # @default -- Read each value below.
+  awsCloudMap:
+
+    # operator.awsCloudMap.defaultRegion --  The default region to
+    # use for Cloud Map. This is required.
+    # @default -- "". An error will be thrown.
+    defaultRegion: ""
+
+    # operator.awsCloudMap.credentials -- The path to the credentials file
+    # to use to authenticate to AWS. **DO NOT** set this explicitly,
+    # but rather supply this information during installation with `--set-file`.
+    # See [Examples](#examples) section.
+    # @default -- **DO NOT** set explicitly: see [Examples](#examples).
+    credentials: ""
 
   cloudMetadata:
     # operator.cloudMetadata.network -- Whether to register the current


### PR DESCRIPTION
This new version of the Helm Chart is now able to install the operator to its latest version (`v0.7.0`) and includes documentation and examples as well.

For a list of changes to the operator, please refer to [its official release](https://github.com/CloudNativeSDWAN/cnwan-operator/releases/tag/v0.7.0)